### PR TITLE
[ADD] Implement rate limit request by 8 RPS (Request per second)

### DIFF
--- a/components/AccountInfo.js
+++ b/components/AccountInfo.js
@@ -175,8 +175,8 @@ export default function AccountInfo(props) {
     const fetchLastMineTx = async (tx) => {
         await delay(getRandom(300,5000))
         if(tx == "None") { return }
-        const lastMineTLM = await axios.get(`https://wax.eosrio.io/v2/history/get_transaction?id=${tx}`,{
-            timeout: 10000
+        const lastMineTLM = await axios.get(`https://wax.blokcrafters.io/v2/history/get_transaction?id=${tx}`,{
+            timeout: 15000
         }
         ).then(function({data}) {
             return data.actions[1].act.data.amount
@@ -190,14 +190,14 @@ export default function AccountInfo(props) {
             .then(({data}) => data.traces[1].act.data.quantity.slice(0, -4))
             .catch((err2) => {
                 console.log("Fallback Greymass err")
-                console.log(err2.response)
-                return axios.get(`https://wax.blokcrafters.io/v2/history/get_transaction?id=${tx}`,{
+                //console.log(err2.response)
+                return axios.get(`https://wax.eosrio.io/v2/history/get_transaction?id=${tx}`,{
                     timeout: 15000
                 })
                 .then(({data}) => data.actions[1].act.data.amount)
                 .catch((err3) => {
                     console.log("3rd Fallback error")
-                    console.log(err3.response)
+                    //console.log(err3.response)
                     return axios.get(`/get_tx/${tx}`)
                     .then(({data}) => data.actions[1].act.data.amount)
                     .catch((err4) => {

--- a/components/AccountInfo.js
+++ b/components/AccountInfo.js
@@ -1,10 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
-import axios from 'axios'
 const { DateTime } = require("luxon");
 import delay from 'delay'
 
 export default function AccountInfo(props) {
-    const { account, onDelete, onBalChange, index } = props
+    const { account, onDelete, onBalChange, index, axios } = props
 
     const [acc, setAcc] = useState(account)
     const [loading, setLoading] = useState(true)
@@ -29,7 +28,7 @@ export default function AccountInfo(props) {
     const fetchAccountData = async (user) => {
         await delay(getRandom(100, 2000))
         return axios.get(`https://wax.blokcrafters.io/v2/state/get_account?account=${user}`, {
-            timeout: 30000
+            timeout: 15000
         })
         .then((resp) => {
             if(resp.status == 200) {
@@ -54,9 +53,10 @@ export default function AccountInfo(props) {
             }
         })
         .catch(async (err) => {
-            if(err.response.status === 500 && err.response.data.message.includes("not found")) return
+            console.log(err)
+            if(err.response && err.response.status === 500 && err.response.data.message.includes("not found")) return
             return axios.get(`https://wax.cryptolions.io/v2/state/get_account?account=${user}`, {
-                timeout: 30000
+                timeout: 15000
             })
             .then((resp) => {
                 if(resp.status == 200) {
@@ -91,7 +91,7 @@ export default function AccountInfo(props) {
         const minerName = await axios.post('https://wax.pink.gg/v1/chain/get_table_rows',
         {json: true, code: "federation", scope: "federation", table: 'players', lower_bound: user, upper_bound: user},
         {
-            timeout: 30000
+            timeout: 15000
         }
         ).then(function({data}) {
             //console.log(data.rows[0]);
@@ -119,7 +119,7 @@ export default function AccountInfo(props) {
         const lastMineData = await axios.post('https://wax.eosn.io/v1/chain/get_table_rows',
         {json: true, code: "m.federation", scope: "m.federation", table: 'miners', lower_bound: user, upper_bound: user},
         {
-            timeout: 30000
+            timeout: 15000
         }
         ).then(function({data}) {
             //console.log(data.rows[0]);
@@ -176,23 +176,23 @@ export default function AccountInfo(props) {
         await delay(getRandom(300,5000))
         if(tx == "None") { return }
         const lastMineTLM = await axios.get(`https://wax.eosrio.io/v2/history/get_transaction?id=${tx}`,{
-            timeout: 30000
+            timeout: 10000
         }
         ).then(function({data}) {
             return data.actions[1].act.data.amount
         }).catch(async (err) => {
-            console.log("EOSRIO ERR")
-            //console.log(err)
+            //console.log("EOSRIO ERR")
+            //console.log(err.message)
             await delay(getRandom(300,5000))
             return axios.get(`https://wax.greymass.com/v1/history/get_transaction?id=${tx}`,{
-                timeout: 30000
+                timeout: 15000
             })
             .then(({data}) => data.traces[1].act.data.quantity.slice(0, -4))
             .catch((err2) => {
                 console.log("Fallback Greymass err")
                 console.log(err2.response)
                 return axios.get(`https://wax.blokcrafters.io/v2/history/get_transaction?id=${tx}`,{
-                    timeout: 30000
+                    timeout: 15000
                 })
                 .then(({data}) => data.actions[1].act.data.amount)
                 .catch((err3) => {

--- a/components/AccountTable.js
+++ b/components/AccountTable.js
@@ -1,5 +1,6 @@
-import AccountInfo from './AccountInfo'
-import { useState, useEffect } from 'react'
+import AccountInfo from './AccountInfo';
+import { useState, useEffect } from 'react';
+import http from './Axios';
 
 export default function AccountTable(props) {
     const { accounts, onDelete, onTotalChange } = props
@@ -37,7 +38,7 @@ export default function AccountTable(props) {
             {accounts.length === 0 && <span className="text-3xl font-bold text-center text-red-400">No accounts added yet!</span>}
             {accounts.length > 0 && accounts.map((acc, i) => {
                 return (
-                    <AccountInfo key={i} index={i} account={acc} onDelete={onDelete} onBalChange={(amt) => onBalChange(i, amt)} />
+                    <AccountInfo key={i} index={i} account={acc} onDelete={onDelete} onBalChange={(amt) => onBalChange(i, amt)} axios={http} />
                 )
             })}
         </div>

--- a/components/Axios.js
+++ b/components/Axios.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+
+const http = rateLimit(axios.create(), { maxRequests: 8, perMilliseconds: 1000 })
+console.log("MAX RPS: "+http.getMaxRPS())
+
+export default http;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "atob": "^2.1.2",
         "axios": "^0.21.1",
+        "axios-rate-limit": "^1.3.0",
         "btoa": "^1.2.1",
         "crypto-js": "^4.0.0",
         "delay": "^5.0.0",
@@ -468,6 +469,14 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "node_modules/axios-rate-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz",
+      "integrity": "sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw==",
+      "peerDependencies": {
+        "axios": "*"
       }
     },
     "node_modules/babel-plugin-syntax-jsx": {
@@ -4005,6 +4014,12 @@
       "requires": {
         "follow-redirects": "^1.10.0"
       }
+    },
+    "axios-rate-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz",
+      "integrity": "sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw==",
+      "requires": {}
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "atob": "^2.1.2",
     "axios": "^0.21.1",
+    "axios-rate-limit": "^1.3.0",
     "btoa": "^1.2.1",
     "crypto-js": "^4.0.0",
     "delay": "^5.0.0",

--- a/pages/api/get_account/[name].js
+++ b/pages/api/get_account/[name].js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import delay from 'delay'
 
 export default async (req, res) => {
+    console.log("/get_account called")
     const {
         query: { name },
     } = req

--- a/pages/api/get_balance/[name]/[currency].js
+++ b/pages/api/get_balance/[name]/[currency].js
@@ -6,6 +6,7 @@ export default async (req, res) => {
     const {
         query: { name, currency },
     } = req
+    console.log(`/get_balance/${currency} called`)
     //console.log(name, currency)
     if(!name || name == '' || typeof name == 'undefined' || !currency
     || typeof currency == 'undefined') {

--- a/pages/api/get_last_mine/[name].js
+++ b/pages/api/get_last_mine/[name].js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import delay from 'delay'
 
 export default async (req, res) => {
+    console.log("/get_last_mine called")
     const {
         query: { name },
     } = req

--- a/pages/api/get_tag/[name].js
+++ b/pages/api/get_tag/[name].js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import delay from 'delay'
 
 export default async (req, res) => {
+    console.log("/get_tag called")
     const {
         query: { name },
     } = req

--- a/pages/api/get_tx/[tx].js
+++ b/pages/api/get_tx/[tx].js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import delay from 'delay'
 
 export default async (req, res) => {
+    console.log("/get_tx called")
     const {
         query: { tx },
     } = req


### PR DESCRIPTION
Since the API Endpoint of WAX that we use to get information almost set rate limit for requests around 1000 request per 1 minutes.

If we sending too much requests, the API will return error code 429 (Too Many Request) and that result as the error on the page or some information is loading as not showing any updates.

I decided to implement rate limit for axios that will limited to send 8 requests per seconds (~500 request/min).

I hope that this implementation will reduce any error come from API Error 429.